### PR TITLE
Add warnings section & update installer to check for default password

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 Linux driver for *`process`/`region`/`memory`* inspection & manipulation via HTTP.
 
+# Warnings
+
+This driver provides memory access for ***all running processes*** over HTTP. 
+
+Please review the following warnings before using this tool:
+
+### (1) This should not be used on public networks
+
+This driver utilizes [Basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) to verify users. The Username and Password is passed clear-text over the network, which is generally regarded as being unsecure. While this may be fine on networks you have control over, running this driver on public networks should be avoided.
+
+### (2) Change the default Username / Password
+
+Please change the default Username & Password from "guest" to something else. It is your last line of defense to prevent malicious users from modifying/reading your system memory. 
+
+### (3) Be wary when using 3rd party tools
+
+This driver is not locked to any single process. Assume that websites utilizing this driver contain malicious code. 
+
+The only "trusted" tool utilizing this driver is [http-game-apex](https://xradius.github.io/http-game-apex/).
+
+
 # Installation
 
 This guide is written for *Ubuntu*. For other Linux flavors, adapt commands where needed.

--- a/service-install.sh
+++ b/service-install.sh
@@ -4,8 +4,26 @@ echo "This installation script will register a system service. When finished, th
 echo "of this service is readable by any user. To make sure that it cannot be used for"
 echo "detection purposes, you have to enter a random service name. Ensure that it does"
 echo "not exist already, and only use characters in [0-9A-Z-]."
+echo ""
+echo "Additionally, please refer to https://github.com/XRadius/http-driver#warnings"
+echo "before continuing to understand the security implications of this tool."
 echo "================================================================================"
 read -p "ServiceName: " serviceName
+
+# ====================
+# 
+# ====================
+
+if grep Password ./src/appsettings.json | sed -r 's/^[^:]*:(.*)$/\1/' | grep -q guest;
+then
+   echo ""
+   echo "Default password used. This is not safe!"
+   echo "See: https://github.com/XRadius/http-driver#warnings for more information."
+   read -p "Continue? [y/N]: " continueInstall
+   if [[ ! "$continueInstall" =~ ^([yY][eE][sS]|[yY])$ ]];
+   then echo "Please change the password. Exiting..." && exit 3;
+   fi;
+fi
 
 # ====================
 # 


### PR DESCRIPTION
I added a warnings section to clarify the security implications of using this tool. In addition, I updated the service-install.sh script to check the src/appsettings.json file to see if the password is set to default.